### PR TITLE
[FIX] Fix persistent messages

### DIFF
--- a/src/js/controllers/app.js
+++ b/src/js/controllers/app.js
@@ -86,14 +86,18 @@ module.controller('AppCtrl', ['$rootScope', '$compile', 'rpId', 'rpNetwork',
     fs.writeFile(fileName, txData, function(err) {
       $scope.$apply(function() {
         $scope.fileName = fileName;
-        console.log('saved file');
         if (err) {
           console.log('Error saving transaction: ', JSON.stringify(err));
           $scope.error = true;
         } else {
+          console.log('saved file');
           $scope.saved = true;
         }
       });
+      // Reset root scope vars so messages do not persist accross controllers
+      setTimeout(function() {
+        $scope.error = $scope.saved = undefined;
+      }, 1000);
     });
   };
 


### PR DESCRIPTION
I noticed the root scope variables were never getting reset to `undefined` after they were initially set in this method.  As a consequence, the success/failure messages would persist across controllers. Also, if a txn saved successfully, then one saved with an error, both the success and error messages would be displayed. Here we reset the variables. This happens outside an `$apply`, so the actual value of the timeout is not particularly important here. The messages will persist until the user navigates to another tab, after which the updates to the `$scope` will be reflected in the UI.